### PR TITLE
Sets the correct status code on bail out

### DIFF
--- a/example-output.3.txt
+++ b/example-output.3.txt
@@ -1,0 +1,6 @@
+TAP version 13
+1..4
+ok 1 - Input file opened
+ok 2 - First line of the input valid
+ok 3 - Read the rest of the file
+Bail out! not cool man

--- a/src/tap-color.js
+++ b/src/tap-color.js
@@ -3,11 +3,14 @@ import duplexer from 'duplexer2';
 import through from 'through2';
 import { LineStream } from 'byline';
 
+const notOk = /^\s*not ok \d*/;
+const bailOut = /^Bail out!/;
+
 function color(theLine) {
   return theLine
     .replace(/^\s*ok \d*/, (l) => chalk.green.bold(l))
-    .replace(/^\s*not ok \d*/, (l) => chalk.red.bold(l))
-    .replace(/^Bail out!/, (l) => chalk.red.bold(l))
+    .replace(notOk, (l) => chalk.red.bold(l))
+    .replace(bailOut, (l) => chalk.red.bold(l))
     .replace(/^\s*(TAP version 13|1..\d+)/, (l) => chalk.gray(l))
     .replace(/^\s+---/, (l) => chalk.gray(l))
     .replace(/^\s+\.\.\./, (l) => chalk.gray(l))
@@ -40,10 +43,11 @@ export default function colorStream() {
   const dup = duplexer(lines, output);
 
   lines.on('data', (line) => {
-    if (line.toString().match(/^not ok \d*/)) {
+    const lineString = line.toString();
+    if (lineString.match(notOk) || lineString.match(bailOut)) {
       dup.failed = true;
     }
-    output.push(color(`${line.toString()}\n`));
+    output.push(color(`${lineString}\n`));
   });
   return dup;
 }


### PR DESCRIPTION
This fixes an issue where if the TAP output bailed out without logging a "not ok" line, tap-color would incorrectly return status code 0.

Also fixes an issue where a different regular expression was used to detect "not ok" lines between coloring and detecting the status code.